### PR TITLE
Reduce duplication between TCP/RTU clients

### DIFF
--- a/lib/ex_modbus/client.ex
+++ b/lib/ex_modbus/client.ex
@@ -1,22 +1,20 @@
 defmodule ExModbus.Client do
-  @moduledoc """
-  ModbusTCP client to manage communication with a device
-  """
-
-  use GenServer
+  # use GenServer
   require Logger
-
-  @read_timeout 4000
-
   # Public Interface
 
   def start_link(args, opts \\ [])
-
-  def start_link(ip = {_a, _b, _c, _d}, opts) do
-    start_link(%{ip: ip}, opts)
-  end
-  def start_link(args = %{ip: _ip}, opts) do
+  def start_link({_a, _b, _c, _d} = ip, opts) do
+    args = %{ip: ip, strategy: ExModbus.TcpClient}
     GenServer.start_link(__MODULE__, args, opts)
+  end
+  def start_link(%{tty: _tty, speed: _speed} = args, opts) do
+    args = %{ args | strategy: ExModbus.RtuClient}
+    GenServer.start_link(__MODULE__, args, opts)
+  end
+
+  def init(%{strategy: strategy} = args) do
+    apply(strategy, :init, [args])
   end
 
   def read_data(pid, unit_id, start_address, count) do
@@ -36,12 +34,12 @@ defmodule ExModbus.Client do
 
 
   def write_single_register(pid, unit_id, address, data) do
-    GenServer.call(pid, {:write_single_register, %{unit_id: unit_id, start_address: address, state: data}})
+    GenServer.call(pid, {:write_single_register, %{unit_id: unit_id, start_address: address, data: data}})
   end
 
 
   def write_multiple_registers(pid, unit_id, address, data) do
-    GenServer.call(pid, {:write_multiple_registers, %{unit_id: unit_id, start_address: address, state: data}})
+    GenServer.call(pid, {:write_multiple_registers, %{unit_id: unit_id, start_address: address, data: data}})
   end
 
 
@@ -50,15 +48,7 @@ defmodule ExModbus.Client do
     transform.(data)
   end
 
-
-  # GenServer Callbacks
-
-  def init(%{ip: ip}) do
-    {:ok, socket} = :gen_tcp.connect(ip, Modbus.Tcp.port, [:binary, {:active, false}])
-    {:ok, socket}
-  end
-
-  def handle_call({:read_coils, %{unit_id: unit_id, start_address: address, count: count}}, _from, socket) do
+  def handle_call({:read_coils, %{unit_id: unit_id, start_address: address, count: count}}, _from, {transport, strategy}) do
     # limits the number of coils returned to the number `count` from the request
     limit_to_count = fn msg ->
                         {:read_coils, lst} = msg.data
@@ -66,55 +56,38 @@ defmodule ExModbus.Client do
                         %{msg | data: {:read_coils, elems}}
     end
     response = Modbus.Packet.read_coils(address, count)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
+               |> strategy.send_and_rcv_packet(transport, unit_id)
                |> limit_to_count.()
 
-    {:reply, response, socket}
+    {:reply, response, {transport, strategy}}
   end
 
-  def handle_call({:read_holding_registers, %{unit_id: unit_id, start_address: address, count: count}}, _from, socket) do
+  def handle_call({:read_holding_registers, %{unit_id: unit_id, start_address: address, count: count}}, _from, {transport, strategy}) do
     response = Modbus.Packet.read_holding_registers(address, count)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
-    {:reply, response, socket}
+               |> strategy.send_and_rcv_packet(transport, unit_id)
+    {:reply, response, {transport, strategy}}
   end
 
-  def handle_call({:write_single_coil, %{unit_id: unit_id, start_address: address, state: state}}, _from, socket) do
+  def handle_call({:write_single_coil, %{unit_id: unit_id, start_address: address, state: state}}, _from, {transport, strategy}) do
     response = Modbus.Packet.write_single_coil(address, state)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
-    {:reply, response, socket}
+               |> strategy.send_and_rcv_packet(transport, unit_id)
+    {:reply, response, {transport, strategy}}
   end
 
-  def handle_call({:write_single_register, %{unit_id: unit_id, start_address: address, state: data}}, _from, socket) do
+  def handle_call({:write_single_register, %{unit_id: unit_id, start_address: address, data: data}}, _from, {transport, strategy}) do
     response = Modbus.Packet.write_single_register(address,data)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
-    {:reply, response, socket}
+               |> strategy.send_and_rcv_packet(transport, unit_id)
+    {:reply, response, {transport, strategy}}
   end
 
-  def handle_call({:write_multiple_registers, %{unit_id: unit_id, start_address: address, state: data}}, _from, socket) do
+  def handle_call({:write_multiple_registers, %{unit_id: unit_id, start_address: address, data: data}}, _from, {transport, strategy}) do
     response = Modbus.Packet.write_multiple_registers(address, data)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
-    {:reply, response, socket}
+               |> strategy.send_and_rcv_packet(transport, unit_id)
+    {:reply, response, {transport, strategy}}
   end
 
   def handle_call(msg, _from, state) do
     Logger.info "Unknown handle_cast msg: #{inspect msg}"
     {:reply, "unknown call message", state}
   end
-
-  defp send_and_rcv_packet(msg, socket) do
-    #Logger.debug "Packet: #{inspect msg}"
-    :ok = :gen_tcp.send(socket, msg)
-    {:ok, packet} = :gen_tcp.recv(socket, 0, @read_timeout)
-    # XXX - handle {:error, closed} and try to reconnect
-    #Logger.debug "Response: #{inspect packet}"
-    unwrapped = Modbus.Tcp.unwrap_packet(packet)
-    {:ok, data} = Modbus.Packet.parse_response_packet(unwrapped.packet)
-    %{unit_id: unwrapped.unit_id, transaction_id: unwrapped.transaction_id, data: data}
-  end
-
 end

--- a/lib/ex_modbus/rtu_client.ex
+++ b/lib/ex_modbus/rtu_client.ex
@@ -2,42 +2,9 @@ defmodule ExModbus.RtuClient do
   @moduledoc """
   ModbusRTU client to manage communication with a device
   """
-
-  use GenServer
   require Logger
 
   @read_timeout 5000
-
-  # Public Interface
-
-  def start_link(args = %{tty: _tty, speed: _speed}, opts \\ []) do
-    GenServer.start_link(__MODULE__, args, opts)
-  end
-
-  def read_data(pid, slave_id, start_address, count) do
-    GenServer.call(pid, {:read_holding_registers, %{slave_id: slave_id, start_address: start_address, count: count}})
-  end
-
-  def read_coils(pid, slave_id, start_address, count) do
-    GenServer.call(pid, {:read_coils, %{slave_id: slave_id, start_address: start_address, count: count}})
-  end
-
-  @doc """
-  Write a single coil at address. Possible states are `:on` and `:off`.
-  """
-  def write_single_coil(pid, slave_id, address, state) do
-    GenServer.call(pid, {:write_single_coil, %{slave_id: slave_id, start_address: address, state: state}})
-  end
-
-  def write_multiple_registers(pid, slave_id, address, data) do
-    GenServer.call(pid, {:write_multiple_registers, %{slave_id: slave_id, start_address: address, state: data}})
-  end
-
-  def generic_call(pid, slave_id, {call, address, count, transform}) do
-    %{data: {_type, data}} = GenServer.call(pid, {call, %{slave_id: slave_id, start_address: address, count: count}})
-    transform.(data)
-  end
-
 
   # GenServer Callbacks
 
@@ -45,67 +12,15 @@ defmodule ExModbus.RtuClient do
      {:ok, uart_pid} = Nerves.UART.start_link
      Nerves.UART.open(uart_pid, tty, speed: speed, active: false)
      Nerves.UART.configure(uart_pid, framing: {ExModbus.Nerves.UART.Framing.Modbus, slave_id: 1})
-     {:ok, uart_pid}
+     {:ok, {uart_pid, ExModbus.RtuClient}}
   end
 
-  def handle_call({:read_coils, %{slave_id: slave_id, start_address: address, count: count}}, _from, serial) do
-    # limits the number of coils returned to the number `count` from the request
-    limit_to_count = fn msg ->
-                        {:read_coils, lst} = msg.data
-                        {_, elems} = Enum.split(lst, -count)
-                        %{msg | data: {:read_coils, elems}}
-    end
-    response = Modbus.Packet.read_coils(address, count)
-               |> Modbus.Rtu.wrap_packet(slave_id)
-               |> send_and_rcv_packet(serial)
-               |> limit_to_count.()
-
-    {:reply, response, serial}
-  end
-
-  def handle_call({:read_holding_registers, %{slave_id: slave_id, start_address: address, count: count}}, _from, serial) do
-    response = Modbus.Packet.read_holding_registers(address, count)
-               |> Modbus.Rtu.wrap_packet(slave_id)
-               |> send_and_rcv_packet(serial)
-    {:reply, response, serial}
-  end
-
-  def handle_call({:write_single_register, %{unit_id: unit_id, start_address: address, state: data}}, _from, socket) do
-    response = Modbus.Packet.write_single_register(address,data)
-               |> Modbus.Tcp.wrap_packet(unit_id)
-               |> send_and_rcv_packet(socket)
-    {:reply, response, socket}
-  end
-
-  def handle_call({:write_single_coil, %{slave_id: slave_id, start_address: address, state: state}}, _from, serial) do
-    response = Modbus.Packet.write_single_coil(address, state)
-               |> Modbus.Rtu.wrap_packet(slave_id)
-               |> send_and_rcv_packet(serial)
-    {:reply, response, serial}
-  end
-
-  def handle_call({:write_multiple_registers, %{slave_id: slave_id, start_address: address, state: data}}, _from, serial) do
-    response = Modbus.Packet.write_multiple_registers(address, data)
-               |> Modbus.Rtu.wrap_packet(slave_id)
-               |> send_and_rcv_packet(serial)
-    {:reply, response, serial}
-  end
-
-  def handle_call(msg, _from, state) do
-    Logger.info "Unknown handle_cast msg: #{inspect msg}"
-    {:reply, "unknown call message", state}
-  end
-
-  def handle_info({:nerves_uart, _tty, data}, state) do
-    Logger.debug "Got back #{inspect data}"
-    {:noreply, state}
-  end
-
-  defp send_and_rcv_packet(msg, serial) do
-    Logger.debug "Sending: #{inspect msg}"
+  def send_and_rcv_packet(msg, serial, unit_id) do
+    wrapped_msg = Modbus.Rtu.wrap_packet(msg, unit_id)
+    Logger.debug "Sending: #{inspect wrapped_msg}"
 
     Nerves.UART.flush(serial)
-    Nerves.UART.write(serial, msg)
+    Nerves.UART.write(serial, wrapped_msg)
 
     case Nerves.UART.read(serial, @read_timeout) do
       # 1 here is slave_id, should be a variable

--- a/lib/ex_modbus/tcp_client.ex
+++ b/lib/ex_modbus/tcp_client.ex
@@ -1,0 +1,26 @@
+defmodule ExModbus.TcpClient do
+  @moduledoc """
+  ModbusTCP client to manage communication with a device
+  """
+
+  require Logger
+
+  @read_timeout 4000
+
+  def init(%{ip: ip}) do
+    {:ok, socket} = :gen_tcp.connect(ip, Modbus.Tcp.port, [:binary, {:active, false}])
+    {:ok, {socket, ExModbus.TcpClient}}
+  end
+
+  def send_and_rcv_packet(msg, socket, unit_id) do
+    wrapped_msg = Modbus.Tcp.wrap_packet(msg, unit_id)
+    #Logger.debug "Packet: #{inspect msg}"
+    :ok = :gen_tcp.send(socket, wrapped_msg)
+    {:ok, packet} = :gen_tcp.recv(socket, 0, @read_timeout)
+    # XXX - handle {:error, closed} and try to reconnect
+    #Logger.debug "Response: #{inspect packet}"
+    unwrapped = Modbus.Tcp.unwrap_packet(packet)
+    {:ok, data} = Modbus.Packet.parse_response_packet(unwrapped.packet)
+    %{unit_id: unwrapped.unit_id, transaction_id: unwrapped.transaction_id, data: data}
+  end
+end

--- a/lib/modbus/rtu.ex
+++ b/lib/modbus/rtu.ex
@@ -5,8 +5,6 @@ defmodule Modbus.Rtu do
 
   alias Modbus.Crc16
 
-  @slave_id 0x0001
-
   # reading functions
   @function_read_coil_status 0x01
   @function_read_input_status 0x02

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule ExModbus.Mixfile do
      version: "0.0.3",
      elixir: ">= 1.0.0",
      description: "An Elixir ModbusTCP client implementation.",
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def package do


### PR DESCRIPTION
Sorry, because this is a fork, I can't create an issue here. So this was the only way I knew to start a conversation.

I'm preparing to start updating the TCP client (handling connection disruptions), but wanted to reduce the duplication with some of the logic first, and check whether you prefer 1 big PR that would include the TCP changes, or break it into this, and a separate one to handle TCP connection issues.

**Alert 1:** This would require a big version bump, because the RtuClient won't work on its own anymore. Everything would just be ExModbus.Client, and it infers your transport (TCP/RTU) based on the parameters you specify.

**Alert 2:** Because there are no specs for any of this, I can't be sure it's all working!  I'll write specs for the TCP code that I upgrade though.